### PR TITLE
web: refrain from sending load errors to chat

### DIFF
--- a/scripts/web.coffee
+++ b/scripts/web.coffee
@@ -18,7 +18,6 @@ module.exports = (robot) ->
       .get(->) (err, res, body) ->
         if err || !res
           console.log "HTTP got error:", err
-          msg.send "Error loading page"
         else if res.statusCode in [301, 302, 303]
           httpResponse(res.headers.location)
         else if res.statusCode is 200


### PR DESCRIPTION
This means non-existent or unresponsive domains won't result in a fairly useless "Error loading page"